### PR TITLE
Reverse dependency fix for JCZ transpiler - Graphix PR #484

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -79,8 +79,9 @@ class TestClient:
         nqubits = 2
         depth = 1
         for _i in range(10):
-            circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
+            circuit = rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
+            pattern = pattern.infer_pauli_measurements()
             pattern.standardize()
 
             state = circuit.simulate_statevector().statevec
@@ -100,8 +101,9 @@ class TestClient:
         nqubits = 2
         depth = 1
         for _i in range(10):
-            circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
+            circuit = rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
+            pattern = pattern.infer_pauli_measurements()
             pattern.standardize()
 
             secrets = Secrets(theta=True)
@@ -129,8 +131,9 @@ class TestClient:
         nqubits = 2
         depth = 1
         for _ in range(10):
-            circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
+            circuit = rand_circuit(nqubits, depth, fx_rng)
             pattern = circuit.transpile().pattern
+            pattern = pattern.infer_pauli_measurements()
             pattern.standardize()
 
             secrets = Secrets(a=True)
@@ -211,7 +214,6 @@ class TestClient:
             pattern = circuit.transpile().pattern
             # pattern.minimize_space()
             # pattern.standardize(method="global")
-            pattern.minimize_space()
             secrets = Secrets(a=True, r=True, theta=True)
 
             # Create a |+> state for each input node, and associate index
@@ -251,9 +253,8 @@ class TestClient:
     def test_graph_clifford_structure(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 10
-        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
+        circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
-        pattern.minimize_space()
         client = Client(pattern=pattern, rng=fx_rng)
         for node in client.graph.nodes:
             x_string = PauliString(["X" if i == node else "I" for i in client.graph.nodes])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ from graphix.measurements import Outcome
 from graphix.random_objects import rand_circuit
 from graphix.sim.statevec import StatevectorBackend
 from graphix.states import BasicStates
+from graphix.transpiler import transpile_swaps
 from numpy.random import Generator
 from stim import PauliString
 from typing_extensions import override
@@ -21,9 +22,10 @@ class TestClient:
         """
         nqubits = 2
         depth = 2
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
         pattern.standardize()
+        pattern.minimize_space()
 
         states = [BasicStates.PLUS for _ in pattern.input_nodes]
 
@@ -39,7 +41,7 @@ class TestClient:
         """
         nqubits = 3
         depth = 5
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
         pattern.minimize_space()
 
@@ -56,7 +58,7 @@ class TestClient:
         # Generate random pattern
         nqubits = 2
         depth = 1
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
         pattern.standardize()
 
@@ -77,7 +79,7 @@ class TestClient:
         nqubits = 2
         depth = 1
         for _i in range(10):
-            circuit = rand_circuit(nqubits, depth, fx_rng)
+            circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
             pattern = circuit.transpile().pattern
             pattern.standardize()
 
@@ -98,7 +100,7 @@ class TestClient:
         nqubits = 2
         depth = 1
         for _i in range(10):
-            circuit = rand_circuit(nqubits, depth, fx_rng)
+            circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
             pattern = circuit.transpile().pattern
             pattern.standardize()
 
@@ -127,7 +129,7 @@ class TestClient:
         nqubits = 2
         depth = 1
         for _ in range(10):
-            circuit = rand_circuit(nqubits, depth, fx_rng)
+            circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
             pattern = circuit.transpile().pattern
             pattern.standardize()
 
@@ -154,7 +156,7 @@ class TestClient:
         # Generate and standardize pattern
         nqubits = 2
         depth = 1
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
         pattern.standardize()
         server_results = dict()
@@ -183,7 +185,7 @@ class TestClient:
     def test_qubits_preparation(self, fx_rng: Generator) -> None:
         nqubits = 2
         depth = 1
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
         pattern.standardize()
         secrets = Secrets(a=True, r=True, theta=True)
@@ -205,11 +207,11 @@ class TestClient:
         # TODO : work on optimization of the quantum communication
         depth = 15
         for _ in range(10):
-            circuit = rand_circuit(nqubits, depth, fx_rng)
+            circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
             pattern = circuit.transpile().pattern
             # pattern.minimize_space()
             # pattern.standardize(method="global")
-
+            pattern.minimize_space()
             secrets = Secrets(a=True, r=True, theta=True)
 
             # Create a |+> state for each input node, and associate index
@@ -234,8 +236,9 @@ class TestClient:
     def test_delegate_pattern(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 10
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         client = Client(pattern=pattern, rng=fx_rng)
 
@@ -248,8 +251,9 @@ class TestClient:
     def test_graph_clifford_structure(self, fx_rng: Generator) -> None:
         nqubits = 5
         depth = 10
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
         client = Client(pattern=pattern, rng=fx_rng)
         for node in client.graph.nodes:
             x_string = PauliString(["X" if i == node else "I" for i in client.graph.nodes])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,12 +256,13 @@ class TestClient:
         circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
         client = Client(pattern=pattern, rng=fx_rng)
+        n = len(client.clifford_structure)
         for node in client.graph.nodes:
-            x_string = PauliString(["X" if i == node else "I" for i in client.graph.nodes])
+            x_string = PauliString(["X" if i == node else "I" for i in range(n)])
             conjugated_string = client.clifford_structure.inverse()(x_string)
             neighbors = set(client.graph.neighbors(node))
             expected_conjugated_string = PauliString(
-                ["X" if i == node else "Z" if i in neighbors else "I" for i in client.graph.nodes]
+                ["X" if i == node else "Z" if i in neighbors else "I" for i in range(n)]
             )
             assert conjugated_string == expected_conjugated_string
 

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 from graphix.random_objects import rand_circuit
 from graphix.sim.statevec import StatevectorBackend
+from graphix.transpiler import transpile_swaps
 from graphix_qasm_parser import OpenQASMParser
 
 from veriphix.blinding import Secrets
@@ -30,8 +31,9 @@ class TestProtocols:
     ) -> None:
         nqubits = 3
         depth = 5
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         protocol = protocol_class()
         client = Client(pattern=pattern, protocol=protocol, rng=fx_rng)
@@ -49,7 +51,7 @@ class TestProtocols:
         parser = OpenQASMParser()
 
         def load_pattern_from_circuit(circuit_label: str) -> Pattern:
-            circuit = parser.parse_file(Path("tests/test_circuits") / circuit_label)
+            circuit = transpile_swaps(parser.parse_file(Path("tests/test_circuits") / circuit_label)).circuit
             pattern = circuit.transpile().pattern
             pattern.minimize_space()
             return pattern
@@ -71,10 +73,11 @@ class TestProtocols:
         # generate random circuit
         nqubits = 2
         depth = 1
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         # transpile to pattern
         pattern = circuit.transpile().pattern
         pattern.standardize()
+        pattern.minimize_space()
 
         # initialise client
         protocol = FK12(manual_colouring=(set([0]), set()))
@@ -90,10 +93,13 @@ class TestProtocols:
         # generate random circuit
         nqubits = 2
         depth = 1
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
+
         # transpile to pattern
         pattern = circuit.transpile().pattern
         pattern.standardize()
+        pattern.minimize_space()
+
 
         nodes = pattern.extract_nodes()
 
@@ -111,8 +117,9 @@ class TestProtocols:
         """
         nqubits = 3
         depth = 5
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         secrets = Secrets(r=True, a=True, theta=True)
         protocol = RandomTraps()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -100,7 +100,6 @@ class TestProtocols:
         pattern.standardize()
         pattern.minimize_space()
 
-
         nodes = pattern.extract_nodes()
 
         # initialise client

--- a/tests/test_vbqc.py
+++ b/tests/test_vbqc.py
@@ -11,6 +11,7 @@ from graphix.random_objects import rand_circuit
 from graphix.sim.density_matrix import DensityMatrixBackend
 from graphix.sim.statevec import StatevectorBackend
 from graphix.states import BasicStates
+from graphix.transpiler import transpile_swaps
 from graphix_qasm_parser import OpenQASMParser
 
 from veriphix.blinding import Secrets
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
 
 def load_pattern_from_circuit(circuit_label: str) -> Pattern:
     parser = OpenQASMParser()
-    circuit = parser.parse_file(Path("tests/test_circuits") / circuit_label)
+    circuit = transpile_swaps(parser.parse_file(Path("tests/test_circuits") / circuit_label)).circuit
     pattern = circuit.transpile().pattern
     pattern.minimize_space()
     return pattern
@@ -36,8 +37,9 @@ class TestVBQC:
     def test_trap_delegated(self, fx_rng: np.random.Generator, blind: bool) -> None:
         nqubits = 3
         depth = 5
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         secrets = Secrets(r=blind, a=blind, theta=blind)
         client = Client(pattern=pattern, secrets=secrets, rng=fx_rng)
@@ -49,8 +51,9 @@ class TestVBQC:
     def test_sample_canvas(self, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 5
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         client = Client(pattern=pattern, rng=fx_rng)
 
@@ -60,8 +63,9 @@ class TestVBQC:
     def test_delegate_canvas(self, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 5
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         svbackend = StatevectorBackend()
         simulated_pattern_output = pattern.simulate_pattern(backend=svbackend, rng=fx_rng)
@@ -96,8 +100,10 @@ class TestVBQC:
     def test_analyze_outcomes(self, fx_rng: Generator, blind: bool) -> None:
         nqubits = 3
         depth = 3
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
+
 
         secrets = Secrets(r=blind, a=blind, theta=blind)
 
@@ -117,7 +123,10 @@ class TestVBQC:
             table = json.load(f)
             circuits = [name for name, prob in table.items()]
         for circuit_label in circuits:
-            pattern = load_pattern_from_circuit(circuit_label=circuit_label)
+            circuit = transpile_swaps(circuit_label).circuit
+            pattern = load_pattern_from_circuit(circuit_label=circuit)
+            pattern.standardize()
+            pattern.minimize_space()
 
             secrets = Secrets(r=blind, a=blind, theta=blind)
 
@@ -136,6 +145,7 @@ class TestVBQC:
         nqubits = 3
         depth = 3
         circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(circuit).circuit
         pattern = circuit.transpile().pattern
 
         states = [BasicStates.PLUS for _ in pattern.input_nodes]
@@ -159,8 +169,9 @@ class TestVBQC:
     def test_noisy(self, fx_rng: Generator) -> None:
         nqubits = 3
         depth = 3
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         states = [BasicStates.PLUS for _ in pattern.input_nodes]
 

--- a/tests/test_vbqc.py
+++ b/tests/test_vbqc.py
@@ -104,7 +104,6 @@ class TestVBQC:
         pattern = circuit.transpile().pattern
         pattern.minimize_space()
 
-
         secrets = Secrets(r=blind, a=blind, theta=blind)
 
         parameters = TrappifiedSchemeParameters(comp_rounds=50, test_rounds=50, threshold=10)

--- a/tests/test_vbqc.py
+++ b/tests/test_vbqc.py
@@ -123,8 +123,7 @@ class TestVBQC:
             table = json.load(f)
             circuits = [name for name, prob in table.items()]
         for circuit_label in circuits:
-            circuit = transpile_swaps(circuit_label).circuit
-            pattern = load_pattern_from_circuit(circuit_label=circuit)
+            pattern = load_pattern_from_circuit(circuit_label=circuit_label)
             pattern.standardize()
             pattern.minimize_space()
 

--- a/tests/test_verifying.py
+++ b/tests/test_verifying.py
@@ -1,6 +1,7 @@
 import numpy as np
 from graphix.random_objects import rand_circuit
 from graphix.sim.statevec import StatevectorBackend
+from graphix.transpiler import transpile_swaps
 
 from veriphix.client import Client
 from veriphix.verifying import TestRun
@@ -10,8 +11,9 @@ class TestVerifying:
     def test_delegate_test(self, fx_rng: np.random.Generator) -> None:
         nqubits = 3
         depth = 5
-        circuit = rand_circuit(nqubits, depth, fx_rng)
+        circuit = transpile_swaps(rand_circuit(nqubits, depth, fx_rng)).circuit
         pattern = circuit.transpile().pattern
+        pattern.minimize_space()
 
         client = Client(pattern=pattern, rng=fx_rng)
 

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -84,6 +84,7 @@ def remove_flow(pattern: Pattern) -> Pattern:
         # pattern types will become more precise in the near future.
         # See https://github.com/TeamGraphix/graphix/issues/266
         clean_pattern.add(cast("Command", new_cmd))
+    clean_pattern.reorder_output_nodes(pattern.output_nodes)
     return clean_pattern
 
 


### PR DESCRIPTION
This PR makes small changes to Veriphix to ensure it functions with the new [J-CZ transpiler in Graphix](https://github.com/TeamGraphix/graphix/pull/484). This includes inference of Pauli nodes and swap transpilation to reduce simulation computation.