### PR TITLE
Fix non-deterministic output-node traps: account for C commands in clifford_structure

### DIFF
--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -88,11 +88,32 @@ def remove_flow(pattern: Pattern) -> Pattern:
     return clean_pattern
 
 
-def get_graph_clifford_structure(graph: nx.Graph[int]) -> stim.Tableau:
+# Single-qubit Clifford factors of ``Clifford.hsz`` mapped to their Stim gate
+# name. ``Clifford.I`` is a no-op and is therefore absent (skipped below).
+_CLIFFORD_TO_STIM_GATE = {Clifford.H: "H", Clifford.S: "S", Clifford.Z: "Z"}
+
+
+def get_graph_clifford_structure(graph: nx.Graph[int], pattern: Pattern | None = None) -> stim.Tableau:
+    """Stim tableau of the Clifford the server applies to the graph state.
+
+    The graph edges give the CZ layer. When ``pattern`` is provided, the
+    single-qubit Clifford byproducts left by ``perform_pauli_measurements`` as
+    ``C(node, clifford)`` commands (typically on output nodes) are composed on
+    top, so the common stabilizer of a test run is correct on those nodes as
+    well. Without this, a trap touching such a node is conjugated by an
+    incomplete structure and comes out non-deterministic (~0.5).
+    """
     circuit = stim.Circuit()
     for edge in graph.edges:
         i, j = edge
         circuit.append_from_stim_program_text(f"CZ {i} {j}")
+    if pattern is not None:
+        for cmd in pattern:
+            if cmd.kind == CommandKind.C:
+                for gate in reversed(cmd.clifford.hsz):
+                    stim_gate = _CLIFFORD_TO_STIM_GATE.get(gate)
+                    if stim_gate is not None:
+                        circuit.append(stim_gate, [cmd.node])
     return circuit.to_tableau()
 
 
@@ -145,7 +166,7 @@ class Client:
             self._add_measurement_commands(self.initial_pattern)
 
         self.graph = self.initial_pattern.extract_graph()
-        self.clifford_structure = get_graph_clifford_structure(self.graph)
+        self.clifford_structure = get_graph_clifford_structure(self.graph, self.initial_pattern)
 
     def create_blind_patterns(
         self,


### PR DESCRIPTION
## Problem
In a test run, a trap that touches an output node fails ~0.5 (non-deterministic), while internal-node traps stay deterministic. This shows up on the statevector oracle itself, before any backend.

After `perform_pauli_measurements`, output nodes carry a `C(node, Clifford)` byproduct (e.g. `C(out, H)` for a QFT). `remove_flow` keeps these `C` commands, so the server applies them, but `get_graph_clifford_structure` builds the common-stabilizer tableau from the graph's CZ edges only and ignores them. For any trap on an output node the conjugated measurement is then wrong, giving a uniform outcome.

The `C` command is standard: graphix's statevector simulator and its QASM3 exporter both apply it; `get_graph_clifford_structure` is the only consumer that skips it.

## Fix
Compose the pattern's `C(node, Clifford)` commands onto the CZ tableau via `Clifford.hsz`. `get_graph_clifford_structure` gains an optional `pattern` argument; `preprocess_pattern` passes `self.initial_pattern`. No-op for patterns without `C` commands, so existing behaviour is unchanged.

## Validation
Reproducible with graphix + veriphix only: build a pattern that leaves a `C(node, Clifford)` on an output node after `perform_pauli_measurements` (e.g. a 3-qubit QFT), construct a `Client`, and run test-run delegations on `StatevectorBackend`. Output-node traps go from non-deterministic to deterministic:

| clifford_structure | output-node traps | internal-node traps |
|---|---|---|
| CZ edges only (before) | ~0.5 | 0.0 |
| CZ + composed C (after) | 0.0 | 0.0 |

The Clifford -> Stim mapping was checked against `Clifford.matrix` for H/S/Z/X/Y.

## Notes
- PR #22 relocates `get_graph_clifford_structure` into `build_stabilizer`, which still builds from the graph only. Happy to move this fix there instead if you'd rather land it in that refactor.
- I didn't add a regression test, since I couldn't reproduce the CI's exact graphix pin locally. Happy to add one (output-node trap determinism on a Pauli-preprocessed non-Clifford pattern) if you point me at the intended setup.
