### PR TITLE
Fix node ordering and refresh of computation states

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,7 +88,7 @@ class TestClient:
 
             backend = StatevectorBackend()
             # Initialize the client
-            secrets = Secrets(r=True)
+            secrets = Secrets(r=True, a=False, theta=False)
             # Giving it empty will create a random secret
             client = Client(pattern=pattern, secrets=secrets, classical_output=False, rng=fx_rng)
             ComputationRun(client).delegate(backend, rng=fx_rng)
@@ -105,7 +105,7 @@ class TestClient:
             pattern = circuit.transpile().pattern
             pattern.standardize()
 
-            secrets = Secrets(theta=True)
+            secrets = Secrets(theta=True, a=False, r=False)
 
             # Create a |+> state for each input node
             states = [BasicStates.PLUS for node in pattern.input_nodes]
@@ -134,7 +134,7 @@ class TestClient:
             pattern = circuit.transpile().pattern
             pattern.standardize()
 
-            secrets = Secrets(a=True)
+            secrets = Secrets(a=True, r=False, theta=False)
 
             # Create a |+> state for each input node
             states = [BasicStates.PLUS for __ in pattern.input_nodes]
@@ -170,7 +170,7 @@ class TestClient:
                 super().store_measurement_outcome(node, result)
 
         # Initialize the client
-        secrets = Secrets(r=True)
+        secrets = Secrets(r=True, a=False)
         # Giving it empty will create a random secret
         client = Client(pattern=pattern, measure_method_cls=CacheMeasureMethod, secrets=secrets, rng=fx_rng)
         backend = StatevectorBackend()
@@ -179,9 +179,9 @@ class TestClient:
         for measured_node in client.measurement_db:
             # Compare results on the client side and on the server side : should differ by r[node]
             result = client.results[measured_node]
-            client_r_secret = client.secret_datas.r[measured_node]
+            client_flip_value = client.secret_datas.r[measured_node] ^ client.secret_datas.a.a_N.get(measured_node, 0)
             server_result = server_results[measured_node]
-            assert result == (server_result + client_r_secret) % 2
+            assert result == (server_result + client_flip_value) % 2
 
     def test_qubits_preparation(self, fx_rng: Generator) -> None:
         nqubits = 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,9 @@
 import unittest
 
+import networkx as nx
 import numpy as np
+import pytest
+from graphix import Measurement, OpenGraph
 from graphix.measurements import Outcome
 from graphix.random_objects import rand_circuit
 from graphix.sim.statevec import StatevectorBackend
@@ -252,14 +255,67 @@ class TestClient:
         circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
         client = Client(pattern=pattern, rng=fx_rng)
+        node_upper_bound = max(client.graph.nodes) + 1
         for node in client.graph.nodes:
-            x_string = PauliString(["X" if i == node else "I" for i in client.graph.nodes])
+            x_string = PauliString(node_upper_bound)
+            x_string[node] = "X"
             conjugated_string = client.clifford_structure.inverse()(x_string)
-            neighbors = set(client.graph.neighbors(node))
-            expected_conjugated_string = PauliString(
-                ["X" if i == node else "Z" if i in neighbors else "I" for i in client.graph.nodes]
-            )
+            expected_conjugated_string = PauliString(node_upper_bound)
+            expected_conjugated_string[node] = "X"
+            for i in client.graph.neighbors(node):
+                expected_conjugated_string[i] = "Z"
             assert conjugated_string == expected_conjugated_string
+
+    def test_reorder_output_nodes(self, fx_rng: Generator) -> None:
+        # Verify that the delegate simulation respects the
+        # non-standard ordering of output nodes (i.e., [2, 1] instead
+        # of the usual [1, 2]).
+        og = OpenGraph(graph=nx.path_graph(3), input_nodes=[], output_nodes=[2, 1], measurements={0: Measurement.X})
+        pattern = og.to_pattern()
+        state_ref = pattern.simulate_pattern()
+        backend = StatevectorBackend()
+        secrets = Secrets()
+        client = Client(pattern=pattern, secrets=secrets, classical_output=False, rng=fx_rng)
+        ComputationRun(client).delegate(backend, rng=fx_rng)
+        state_veriphix = backend.state
+        assert state_veriphix.isclose(state_ref)
+
+    def test_refresh_computation_states(self, fx_rng: Generator) -> None:
+        # Verify that the "computation states" are regenerated when
+        # `refresh_randomness` is called.
+        # In particular, if the initial secret and the refreshed one
+        # do not flip the input state in the same way, the computation
+        # states must be updated after the secret refresh.
+        og = OpenGraph(
+            graph=nx.Graph([(0, 1)]), input_nodes=[0], output_nodes=[1], measurements={0: Measurement.XY(0.75)}
+        )
+        pattern = og.to_pattern()
+        state_ref = pattern.simulate_pattern()
+        backend = StatevectorBackend()
+        secrets = Secrets(a=True)
+        fixed_rng = np.random.default_rng(0)
+        client = Client(pattern=pattern, secrets=secrets, classical_output=False, rng=fixed_rng)
+        old_a = client.secret_datas.a.a.get(0, 0)
+        ComputationRun(client).delegate(backend, rng=fixed_rng)
+        new_a = client.secret_datas.a.a.get(0, 0)
+        # fixed_rng is chosen to satisfy the following assertion.
+        assert old_a != new_a
+        state_veriphix = backend.state
+        assert state_veriphix.isclose(state_ref)
+
+    def test_reject_yz_measurement(self, fx_rng: Generator) -> None:
+        og = OpenGraph(
+            graph=nx.Graph([(0, 1)]), input_nodes=[], output_nodes=[1], measurements={0: Measurement.YZ(0.5)}
+        )
+        pattern = og.to_pattern()
+        state_ref = pattern.simulate_pattern()
+        backend = StatevectorBackend()
+        secrets = Secrets()
+        with pytest.raises(ValueError, match="UBQC only works for measurements in plane XY"):
+            client = Client(pattern=pattern, secrets=secrets, classical_output=False, rng=fx_rng)
+            ComputationRun(client).delegate(backend, rng=fx_rng)
+            state_veriphix = backend.state
+            assert state_veriphix.isclose(state_ref)
 
 
 if __name__ == "__main__":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -26,7 +26,6 @@ class TestClient:
         depth = 2
         circuit = rand_circuit(nqubits, depth, fx_rng)
         pattern = circuit.transpile().pattern
-        pattern.remove_pauli_measurements()
         pattern.standardize()
 
         states = [BasicStates.PLUS for _ in pattern.input_nodes]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -292,7 +292,7 @@ class TestClient:
         state_ref = pattern.simulate_pattern()
         backend = StatevectorBackend()
         secrets = Secrets(a=True)
-        fixed_rng = np.random.default_rng(0)
+        fixed_rng = np.random.default_rng(3)
         client = Client(pattern=pattern, secrets=secrets, classical_output=False, rng=fixed_rng)
         old_a = client.secret_datas.a.a.get(0, 0)
         ComputationRun(client).delegate(backend, rng=fixed_rng)

--- a/veriphix/blinding.py
+++ b/veriphix/blinding.py
@@ -83,10 +83,8 @@ class SecretDatas:
         return SecretDatas(r, Secret_a(a, a_N), theta)
 
     def blind_angle(self, node: int) -> Angle:
-        r_value = self.r.get(node, 0)
         theta_value = self.theta.get(node, 0)
-        a_N_value = self.a.a_N.get(node, 0)
-        return theta_value * ANGLE_PI / 4 + ANGLE_PI * (r_value ^ a_N_value)
+        return theta_value * ANGLE_PI / 4
 
     def blind_qubit(self, node: int, state: State) -> Statevec:
         def z_rotation(theta: float) -> npt.NDArray[np.complex128]:
@@ -95,12 +93,18 @@ class SecretDatas:
         def x_blind(a: Outcome) -> Pauli:
             return Pauli.X if a == 1 else Pauli.I
 
+        def z_blind(r: Outcome) -> Pauli:
+            return Pauli.Z if r == 1 else Pauli.I
+
         theta = self.theta.get(node, 0)
-        a = self.a.a.get(node, 0)
+        x_blind_value = self.a.a.get(node, 0)
+        r = self.r.get(node, 0)
         single_qubit_backend = StatevectorBackend()
         single_qubit_backend.add_nodes([0], [state])
-        if a:
-            single_qubit_backend.apply_single(node=0, op=x_blind(a).matrix)
+        if x_blind_value:
+            single_qubit_backend.apply_single(node=0, op=x_blind(x_blind_value).matrix)
+        if r:
+            single_qubit_backend.apply_single(node=0, op=z_blind(r).matrix)
         if theta:
             single_qubit_backend.apply_single(node=0, op=z_rotation(theta))
         return single_qubit_backend.state

--- a/veriphix/blinding.py
+++ b/veriphix/blinding.py
@@ -24,12 +24,28 @@ if TYPE_CHECKING:
 
 @dataclass
 class Secret_a:
+    """The ``X``-Pauli encryption secrets.
+
+    ``a`` is the per-input-node ``X`` encryption (only input nodes carry it,
+    since ``X|+> = |+>`` makes it useless on the default-prepared nodes). ``a_N``
+    is the induced ``X`` encryption seen at each node, computed from the parity of
+    the ``a`` secrets of its neighbours once the entangling ``CZ``\\ s are applied.
+    """
+
     a: dict[int, Outcome]
     a_N: dict[int, Outcome]
 
 
 @dataclass
 class Secrets:
+    """Toggles for which blinding secrets are generated.
+
+    - ``r``: the one-time-pad applied to every node, so that every result
+      (including a quantum output) is masked.
+    - ``a``: the ``X``-Pauli encryption, only meaningful on input nodes.
+    - ``theta``: the ``Z``-rotation encryption applied to every measured node.
+    """
+
     r: bool = True
     a: bool = True
     theta: bool = True
@@ -46,34 +62,44 @@ class SecretDatas:
         secrets: Secrets,
         graph: nx.Graph[int],
         input_nodes: AbstractSet[int],
-        output_nodes: AbstractSet[int],
+        unmeasured_nodes: AbstractSet[int],
         rng: Generator | None = None,
         *,
         stacklevel: int = 1,
     ) -> SecretDatas:
+        """Sample the blinding secrets for the whole graph.
+
+        ``unmeasured_nodes`` should be empty for a classical output and the set of
+        quantum output nodes otherwise: it is exactly the set of *unmeasured*
+        nodes, which therefore receive no ``theta`` encryption.
+        """
         rng = ensure_rng(rng, stacklevel=stacklevel + 1)
         r = {}
         if secrets.r:
-            # Need to generate the random bit for each qubit
+            # `r` is a one-time-pad on every node: every result, including a
+            # quantum output, must be masked, so we draw a random bit per qubit.
             for node in graph.nodes:
                 r[node] = outcome(rng.integers(2) == 1)
 
         theta = {}
         if secrets.theta:
-            # Create theta secret for all non-output nodes (measured qubits)
+            # `theta` (a Z-rotation, in pi/4 units) is only applied to measured
+            # nodes, i.e. all nodes except the quantum output ones. Unmeasured
+            # output nodes get theta = 0.
             for node in graph.nodes:
-                theta[node] = int(rng.integers(0, 8)) if node not in output_nodes else 0  # Expressed in pi/4 units
-                ## TODO:
+                theta[node] = int(rng.integers(0, 8)) if node not in unmeasured_nodes else 0  # Expressed in pi/4 units
         a: dict[int, Outcome] = {}
         a_N: dict[int, Outcome] = {}
         if secrets.a:
-            # Create `a` secret for all
-            # order is Z(theta) X |+>
+            # `a` is the X-Pauli encryption. Only input nodes get it: the other
+            # nodes are prepared in |+> and X|+> = |+>, so it would be a no-op.
+            # The blinding order on a node is Z(theta) X |+>.
             for node in graph.nodes:
                 a[node] = outcome(rng.integers(0, 2) == 1) if node in input_nodes else 0
 
-            # After all the `a` secrets have been generated, the `a_N` value can be
-            # computed from the graph topology
+            # Once all `a` secrets are known, the induced encryption `a_N` at each
+            # node is the parity of its neighbours' `a` (the X Paulis propagated
+            # through the entangling CZs).
             for i in graph.nodes:
                 a_N_value = outcome(sum([a[j] for j in graph.neighbors(i)]) % 2 == 1)
                 a_N[i] = a_N_value
@@ -85,6 +111,15 @@ class SecretDatas:
         return theta_value * ANGLE_PI / 4
 
     def blind_qubit(self, node: int, state: State) -> Statevec:
+        """Apply the secret-dependent blinding to a single prepared qubit.
+
+        The unblinded ``state`` is the secret-independent computation state (the
+        input state for input nodes, ``|+>`` otherwise). The blinding applies, in
+        order, ``Z(theta) Z(r) X(a)`` on top of it: the ``X`` encryption ``a``
+        (input nodes only), the ``Z`` one-time-pad ``r``, then the ``theta``
+        Z-rotation.
+        """
+
         def z_rotation(theta: float) -> npt.NDArray[np.complex128]:
             return np.array([[1, 0], [0, np.exp(1j * theta * np.pi / 4)]], dtype=np.complex128)
 

--- a/veriphix/blinding.py
+++ b/veriphix/blinding.py
@@ -56,7 +56,7 @@ class SecretDatas:
         if secrets.r:
             # Need to generate the random bit for each measured qubit
             for node in graph.nodes:
-                r[node] = outcome(rng.integers(2) == 1) 
+                r[node] = outcome(rng.integers(2) == 1)
 
         theta = {}
         if secrets.theta:

--- a/veriphix/blinding.py
+++ b/veriphix/blinding.py
@@ -82,8 +82,8 @@ class SecretDatas:
 
         return SecretDatas(r, Secret_a(a, a_N), theta)
 
-    def blind_angle(self, node: int, output_node: bool, test: bool) -> Angle:
-        r_value = 0 if (output_node and not test) else self.r.get(node, 0)
+    def blind_angle(self, node: int) -> Angle:
+        r_value = self.r.get(node, 0)
         theta_value = self.theta.get(node, 0)
         a_N_value = self.a.a_N.get(node, 0)
         return theta_value * ANGLE_PI / 4 + ANGLE_PI * (r_value ^ a_N_value)

--- a/veriphix/blinding.py
+++ b/veriphix/blinding.py
@@ -54,7 +54,7 @@ class SecretDatas:
         rng = ensure_rng(rng, stacklevel=stacklevel + 1)
         r = {}
         if secrets.r:
-            # Need to generate the random bit for each measured qubit
+            # Need to generate the random bit for each qubit
             for node in graph.nodes:
                 r[node] = outcome(rng.integers(2) == 1)
 
@@ -76,8 +76,6 @@ class SecretDatas:
             # computed from the graph topology
             for i in graph.nodes:
                 a_N_value = outcome(sum([a[j] for j in graph.neighbors(i)]) % 2 == 1)
-                # for j in graph.neighbors(i):
-                #     a_N_value ^= a[j]
                 a_N[i] = a_N_value
 
         return SecretDatas(r, Secret_a(a, a_N), theta)

--- a/veriphix/blinding.py
+++ b/veriphix/blinding.py
@@ -54,9 +54,9 @@ class SecretDatas:
         rng = ensure_rng(rng, stacklevel=stacklevel + 1)
         r = {}
         if secrets.r:
-            # Need to generate the random bit for each measured qubit, 0 for the rest (output qubits)
+            # Need to generate the random bit for each measured qubit
             for node in graph.nodes:
-                r[node] = outcome(rng.integers(2) == 1) if node not in output_nodes else 0
+                r[node] = outcome(rng.integers(2) == 1) 
 
         theta = {}
         if secrets.theta:

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -136,8 +136,10 @@ class Client:
         self.initial_pattern: Pattern = pattern
         self.classical_output = classical_output
         self.output_predicate = output_predicate
+
         self.input_nodes = pattern.input_nodes.copy()
         self.output_nodes = pattern.output_nodes.copy()
+        self.unmeasured_nodes = set() if classical_output else self.output_nodes
         self.input_state = [BasicStates.PLUS for _ in self.input_nodes] if input_state is None else list(input_state)
         self.protocol = protocol or FK12()
         self.parameters = parameters
@@ -181,7 +183,7 @@ class Client:
             self.secrets,
             self.graph,
             set(self.input_nodes),
-            set() if self.classical_output else set(self.output_nodes),
+            set(self.unmeasured_nodes),
             rng=rng,
         )
 
@@ -208,7 +210,7 @@ class Client:
         return list(self.graph.nodes)
 
     def _add_measurement_commands(self, pattern: Pattern) -> None:
-        for onode in self.output_nodes:
+        for onode in pattern.output_nodes:
             pattern.add(graphix.command.M(node=onode))
 
     def _copy_pattern(self) -> Pattern:
@@ -231,12 +233,21 @@ class Client:
                 self.secrets,
                 self.graph,
                 set(self.input_nodes),
-                set(self.output_nodes),
+                set(self.unmeasured_nodes),
                 rng=rng,
                 stacklevel=stacklevel + 1,
             )
 
     def get_computation_states(self) -> dict[int, State]:
+        """Return the (unblinded) state in which each node is prepared.
+
+        These states do not depend on the secrets: input nodes are prepared in
+        the specific input state desired by the Client, and every other node is
+        prepared in ``|+>`` by default. Because they are secret-independent, the
+        computation states never need to be refreshed; the secret-dependent
+        blinding is applied separately at the blindness level (see
+        :meth:`SecretDatas.blind_qubit`).
+        """
         states = dict()
         for node in self.graph.nodes:
             if node in self.input_nodes:
@@ -303,6 +314,15 @@ class Client:
         return traps_decision, computation_decision, result_analysis
 
     def decode_output_state(self, backend: Backend[_StateT]) -> None:
+        """Undo the blinding on a quantum output state held by the backend.
+
+        When the output is a classical bitstring, the ``r``/``a_N`` decryption is
+        applied automatically when storing each measurement outcome (see
+        :meth:`BlindMeasureMethod.store_measurement_outcome`). When the output is
+        a quantum state, no measurement happens on the output nodes, so the
+        one-time-pad has to be undone here by applying the byproduct corrections
+        computed in :meth:`decode_output`.
+        """
         for node in self.output_nodes:
             z_decoding, x_decoding = self.decode_output(node)
             if z_decoding:
@@ -311,6 +331,16 @@ class Client:
                 backend.correct_byproduct(command.X(node))
 
     def decode_output(self, node: int) -> tuple[int, int]:
+        """Compute the ``(Z, X)`` byproduct corrections to apply on an output node.
+
+        On top of the flow-induced byproduct (the sum over the ``z_domain`` /
+        ``x_domain`` dependencies), the blinding has to be undone:
+
+        - the ``Z`` correction absorbs the ``r`` one-time-pad (applied to every
+          node) and the ``a_N`` encryption (the ``X`` Pauli propagated from the
+          neighbours' ``a`` secrets through the entangling ``CZ``\\ s);
+        - the ``X`` correction absorbs the input node's own ``a`` encryption.
+        """
         z_decoding = sum(self.results[z_dep] for z_dep in self.byproduct_db[node].z_domain) % 2
         z_decoding ^= self.secret_datas.r.get(node, 0) ^ self.secret_datas.a.a_N.get(node, 0)
         x_decoding = sum(self.results[x_dep] for x_dep in self.byproduct_db[node].x_domain) % 2
@@ -342,6 +372,10 @@ class BlindMeasureMethod(MeasureMethod):
 
     @override
     def store_measurement_outcome(self, node: int, result: Outcome) -> None:
+        # The Server returns the outcome of the *blinded* measurement; the Client
+        # decrypts it with `xor r xor a_N` before storing it. `r` is the
+        # one-time-pad applied to every node and `a_N` is the X encryption
+        # propagated from the neighbours' `a` secrets.
         flip_value = self._client.secret_datas.r.get(node, 0) ^ self._client.secret_datas.a.a_N.get(node, 0)
         if flip_value:
             result = toggle_outcome(result)
@@ -365,7 +399,9 @@ class ClientMeasureMethod(BlindMeasureMethod):
         if t_signal:
             measurement = measurement.clifford(Clifford.Z)
         bloch = measurement.to_bloch()
-        # Blind the angle using the Client's secrets
+        # Compensate the blinding inside the measurement angle: the `a` encryption
+        # flips the angle sign (it commutes the X Pauli through the measurement)
+        # and the `theta` encryption is added back via `blind_angle`.
         angle = (-1) ** a_value * bloch.angle + self._client.secret_datas.blind_angle(cmd.node)
         return BlochMeasurement(angle, bloch.plane)
 

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -12,7 +12,7 @@ import graphix.sim.base_backend
 import graphix.sim.statevec
 import graphix.simulator
 import stim
-from graphix import command
+from graphix import Plane, command
 from graphix.clifford import Clifford
 from graphix.command import BaseCommand, BaseM, BaseN, CommandKind
 from graphix.measurements import BlochMeasurement, Measurement, toggle_outcome
@@ -85,6 +85,8 @@ def remove_flow(pattern: Pattern) -> Pattern:
         # pattern types will become more precise in the near future.
         # See https://github.com/TeamGraphix/graphix/issues/266
         clean_pattern.add(cast("CommandType", new_cmd))
+    # See test_reorder_output_nodes.
+    clean_pattern.reorder_output_nodes(pattern.output_nodes)
     return clean_pattern
 
 
@@ -98,6 +100,15 @@ def get_graph_clifford_structure(graph: nx.Graph[int]) -> stim.Tableau:
 
 def qCircuit_predicate(output_string: str) -> bool:
     return int(output_string[0]) == 1
+
+
+def _check_all_measurements_in_xy(pattern: Pattern) -> None:
+    for cmd_m in pattern.extract_measurement_commands().values():
+        plane = cmd_m.measurement.to_bloch().plane
+        if plane != Plane.XY:
+            raise ValueError(
+                f"UBQC only works for measurements in plane XY: {cmd_m.node} is measured in plane {plane.name}."
+            )
 
 
 class Client:
@@ -120,6 +131,8 @@ class Client:
         *,
         stacklevel: int = 1,
     ) -> None:
+        # See test_reject_yz_measurement.
+        _check_all_measurements_in_xy(pattern)
         self.initial_pattern: Pattern = pattern
         self.classical_output = classical_output
         self.output_predicate = output_predicate
@@ -218,6 +231,8 @@ class Client:
                 rng=rng,
                 stacklevel=stacklevel + 1,
             )
+            # See test_refresh_computation_states.
+            self.computation_states = self.get_computation_states()
 
     def get_computation_states(self) -> dict[int, State]:
         states = dict()

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -223,7 +223,7 @@ class Client:
         return copied_pattern.extract_measurement_commands()
 
     def refresh_randomness(self, rng: Generator | None = None, *, stacklevel: int = 1) -> None:
-        "method to refresh random randomness using parameters from Clinent instatiation."
+        "method to refresh random randomness using parameters from Client instantiation."
 
         # refresh only if secrets bool is True; False is no randomness at all.
         if self.secrets is not None:
@@ -235,19 +235,12 @@ class Client:
                 rng=rng,
                 stacklevel=stacklevel + 1,
             )
-            # See test_refresh_computation_states.
-            self.computation_states = self.get_computation_states()
 
     def get_computation_states(self) -> dict[int, State]:
         states = dict()
         for node in self.graph.nodes:
             if node in self.input_nodes:
                 state = self.input_state[node]
-
-            elif (node in self.output_nodes) and (not self.classical_output):
-                r_value = self.secret_datas.r.get(node, 0)
-                a_N_value = self.secret_datas.a.a_N.get(node, 0)
-                state = BasicStates.PLUS if r_value ^ a_N_value == 0 else BasicStates.MINUS
 
             else:
                 state = BasicStates.PLUS
@@ -319,7 +312,7 @@ class Client:
 
     def decode_output(self, node: int) -> tuple[int, int]:
         z_decoding = sum(self.results[z_dep] for z_dep in self.byproduct_db[node].z_domain) % 2
-        z_decoding ^= self.secret_datas.r.get(node, 0)
+        z_decoding ^= self.secret_datas.r.get(node, 0) ^ self.secret_datas.a.a_N.get(node, 0)
         x_decoding = sum(self.results[x_dep] for x_dep in self.byproduct_db[node].x_domain) % 2
         x_decoding ^= self.secret_datas.a.a.get(node, 0)
         return z_decoding, x_decoding
@@ -349,9 +342,9 @@ class BlindMeasureMethod(MeasureMethod):
 
     @override
     def store_measurement_outcome(self, node: int, result: Outcome) -> None:
-        if self._client.secret_datas.r:
-            if self._client.secret_datas.r[node]:
-                result = toggle_outcome(result)
+        flip_value = self._client.secret_datas.r.get(node, 0) ^ self._client.secret_datas.a.a_N.get(node, 0)
+        if flip_value:
+            result = toggle_outcome(result)
         self._client.results[node] = result
 
 

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -178,7 +178,11 @@ class Client:
 
         self.secrets = secrets or Secrets()
         self.secret_datas = SecretDatas.from_secrets(
-            self.secrets, self.graph, set(self.input_nodes), set(self.output_nodes), rng=rng
+            self.secrets,
+            self.graph,
+            set(self.input_nodes),
+            set() if self.classical_output else set(self.output_nodes),
+            rng=rng,
         )
 
         self.clean_pattern = remove_flow(self.initial_pattern)
@@ -240,7 +244,7 @@ class Client:
             if node in self.input_nodes:
                 state = self.input_state[node]
 
-            elif node in self.output_nodes:
+            elif (node in self.output_nodes) and (not self.classical_output):
                 r_value = self.secret_datas.r.get(node, 0)
                 a_N_value = self.secret_datas.a.a_N.get(node, 0)
                 state = BasicStates.PLUS if r_value ^ a_N_value == 0 else BasicStates.MINUS
@@ -369,9 +373,7 @@ class ClientMeasureMethod(BlindMeasureMethod):
             measurement = measurement.clifford(Clifford.Z)
         bloch = measurement.to_bloch()
         # Blind the angle using the Client's secrets
-        angle = (-1) ** a_value * bloch.angle + self._client.secret_datas.blind_angle(
-            cmd.node, cmd.node in self._client.output_nodes, test=False
-        )
+        angle = (-1) ** a_value * bloch.angle + self._client.secret_datas.blind_angle(cmd.node)
         return BlochMeasurement(angle, bloch.plane)
 
 
@@ -379,6 +381,6 @@ class TestMeasureMethod(BlindMeasureMethod):
     @override
     def describe_measurement(self, cmd: BaseM) -> Measurement:
         # Blind the angle using the Client's secrets
-        angle = self._client.secret_datas.blind_angle(cmd.node, cmd.node in self._client.output_nodes, test=True)
+        angle = self._client.secret_datas.blind_angle(cmd.node)
 
         return Measurement.XY(angle)


### PR DESCRIPTION
This commit fixes bugs encountered while switching to the future J+CZ transpiler in Graphix (see TeamGraphix/graphix#484):

- `client.remove_flow` now reorders output nodes, preserving the order of the original pattern. Previously, the order of the original pattern was ignored, which broke the equivalence with the clean pattern when the output nodes of the original pattern did not match the order in which the nodes were introduced by the commands. See `test_reorder_output_nodes`.

- `refresh_randomness` now updates `computation_states`. Previously, computation states remained as they were generated by the initial secret generation, leading to a mismatch between the state of node preparation (using unchanged computation states) and output decoding (using the new secrets). See `test_refresh_computation_states`.

- `test_graph_clifford_structure` has been updated to support graphs in which nodes are not numbered by an initial increasing range of integers.

- `Client` now rejects patterns that contain measurements outside the XY planes, since they cannot be blind. See `test_reject_yz_measurement`.