### PR TITLE
Namespace homogenisation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-graphix @ git+https://github.com/TeamGraphix/graphix.git
+graphix @ git+https://github.com/matulni/graphix.git@rename_methods
 stim>=1.13,<2
 
 # For sampling circuits

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-graphix @ git+https://github.com/matulni/graphix.git@rename_methods
+graphix @ git+https://github.com/TeamGraphix/graphix.git@master
 stim>=1.13,<2
 
 # For sampling circuits

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -95,7 +95,7 @@ class TestProtocols:
         pattern = circuit.transpile().pattern
         pattern.standardize()
 
-        nodes = pattern.extract_nodes()
+        nodes = pattern.nodes()
 
         # initialise client
         protocol = FK12(manual_colouring=(set(nodes), set([next(iter(nodes))])))

--- a/veriphix/blinding.py
+++ b/veriphix/blinding.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     import numpy.typing as npt
     from graphix.fundamentals import Angle
     from graphix.measurements import Outcome
-    from graphix.sim.statevec import Statevec
+    from graphix.sim.statevec import Statevector
     from graphix.states import State
     from numpy.random import Generator
 
@@ -110,7 +110,7 @@ class SecretDatas:
         theta_value = self.theta.get(node, 0)
         return theta_value * ANGLE_PI / 4
 
-    def blind_qubit(self, node: int, state: State) -> Statevec:
+    def blind_qubit(self, node: int, state: State) -> Statevector:
         """Apply the secret-dependent blinding to a single prepared qubit.
 
         The unblinded ``state`` is the secret-independent computation state (the

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -159,7 +159,8 @@ class Client:
         if classical_output:
             self._add_measurement_commands(self.initial_pattern)
 
-        self.graph = self.initial_pattern.graph()
+        og = self.initial_pattern.to_opengraph()
+        self.graph = og.graph
         self.clifford_structure = get_graph_clifford_structure(self.graph)
 
     def create_blind_patterns(

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -103,7 +103,7 @@ def qCircuit_predicate(output_string: str) -> bool:
 
 
 def _check_all_measurements_in_xy(pattern: Pattern) -> None:
-    for cmd_m in pattern.extract_measurement_commands().values():
+    for cmd_m in pattern.measurement_commands().values():
         plane = cmd_m.measurement.to_bloch().plane
         if plane != Plane.XY:
             raise ValueError(
@@ -159,7 +159,7 @@ class Client:
         if classical_output:
             self._add_measurement_commands(self.initial_pattern)
 
-        self.graph = self.initial_pattern.extract_graph()
+        self.graph = self.initial_pattern.graph()
         self.clifford_structure = get_graph_clifford_structure(self.graph)
 
     def create_blind_patterns(
@@ -222,7 +222,7 @@ class Client:
 
     def _get_measurement_db(self) -> dict[int, command.M]:
         copied_pattern = self._copy_pattern()
-        return copied_pattern.extract_measurement_commands()
+        return copied_pattern.measurement_commands()
 
     def refresh_randomness(self, rng: Generator | None = None, *, stacklevel: int = 1) -> None:
         "method to refresh random randomness using parameters from Client instantiation."

--- a/veriphix/client.py
+++ b/veriphix/client.py
@@ -18,7 +18,7 @@ from graphix.command import BaseCommand, BaseM, BaseN, CommandKind
 from graphix.measurements import BlochMeasurement, Measurement, toggle_outcome
 from graphix.pattern import Pattern
 from graphix.rng import ensure_rng
-from graphix.sim.statevec import Statevec
+from graphix.sim.statevec import Statevector
 from graphix.simulator import MeasureMethod, PrepareMethod
 from graphix.states import BasicStates, State
 from typing_extensions import override
@@ -195,7 +195,7 @@ class Client:
             self.test_pattern = self.clean_pattern
         self.computation_states = self.get_computation_states()
 
-        self.preparation_bank: dict[int, Statevec] = {}
+        self.preparation_bank: dict[int, Statevector] = {}
         self.prepare_method = ClientPrepareMethod(self.preparation_bank)
 
     def create_trappified_scheme(self, rng: Generator | None = None, *, stacklevel: int = 1) -> None:
@@ -264,7 +264,7 @@ class Client:
         """
         for node in states_dict:
             blinded_qubit_state = self.secret_datas.blind_qubit(node=node, state=states_dict[node])
-            self.preparation_bank[node] = Statevec(blinded_qubit_state)
+            self.preparation_bank[node] = Statevector(blinded_qubit_state)
 
     def prepare_states(self, backend: Backend[_StateT], states_dict: Mapping[int, State]) -> None:
         # Initializes the bank (all the nodes)
@@ -349,7 +349,7 @@ class Client:
 
 
 class ClientPrepareMethod(PrepareMethod):
-    def __init__(self, preparation_bank: dict[int, Statevec]) -> None:
+    def __init__(self, preparation_bank: dict[int, Statevector]) -> None:
         self.__preparation_bank = preparation_bank
 
     def prepare_node(self, backend: Backend[_StateT], node: int) -> None:

--- a/veriphix/malicious_noise_model.py
+++ b/veriphix/malicious_noise_model.py
@@ -45,7 +45,7 @@ class DephasingNoise(Noise):
         return 1
 
     @override
-    def to_kraus_channel(self) -> KrausChannel:
+    def to_krauschannel(self) -> KrausChannel:
         """Return the Kraus channel describing the noise element."""
         return dephasing_channel(self.prob)
 


### PR DESCRIPTION
See https://github.com/TeamGraphix/graphix/pull/557 in Graphix repository.

In addition to updating the naming conventions, calls to `Pattern.extract_graph` are replaced by `Pattern.to_opengraph().graph`, as the former does not standardize the pattern and it's not correct. It will be removed from the main repo in a future PR.